### PR TITLE
Print package loading only on attach, use `packageStartupMessage`.

### DIFF
--- a/R/datadescription.R
+++ b/R/datadescription.R
@@ -10,4 +10,7 @@
 NULL
 # hack to supress _no visible binding for global variable _ warning in R CMD check.
 utils::globalVariables(c("ratio"), add = TRUE)
-print("loading package quantable")
+
+.onAttach <- function(libname, pkgname) {
+  packageStartupMessage("loading package quantable")
+}


### PR DESCRIPTION
This follows Good practices mentioned in `?.onAttach`.